### PR TITLE
Fix Windows file URI conversions

### DIFF
--- a/packages/types/src/shared/resultBuilders.ts
+++ b/packages/types/src/shared/resultBuilders.ts
@@ -3,6 +3,7 @@ import type {
   Location,
 } from "@internal/types/lsp";
 import { relative } from "path";
+import { fileURLToPath } from "url";
 
 // Define SimpleDiagnostic type
 export interface SimpleDiagnostic {
@@ -183,7 +184,7 @@ export class ReferenceResultBuilder {
    * Add an LSP location as reference
    */
   addLocation(location: Location, text: string): this {
-    const filePath = location.uri.replace("file://", "");
+    const filePath = location.uri.startsWith("file://") ? fileURLToPath(location.uri) : location.uri;
     const relativePath = this.root ? relative(this.root, filePath) : filePath;
 
     this.references.push({

--- a/src/tools/highlevel/externalLibraryTools.ts
+++ b/src/tools/highlevel/externalLibraryTools.ts
@@ -6,6 +6,7 @@ import type { Tool } from "@modelcontextprotocol/sdk/types.js";
 import type { McpToolDef } from "@internal/types";
 import { z } from "zod";
 import { resolve } from "path";
+import { uriToPath } from "../../utils/uriHelpers.ts";
 import {
   getSymbolIndex,
   indexExternalLibrariesForState,
@@ -270,7 +271,7 @@ export async function handleSearchExternalLibrarySymbols(args: any) {
         name: s.name,
         kind: getSymbolKindName(s.kind),
         container: s.containerName,
-        file: s.location.uri.replace("file://", ""),
+        file: uriToPath(s.location.uri),
         detail: s.detail,
       })),
     },

--- a/src/tools/highlevel/getSymbolDetails.ts
+++ b/src/tools/highlevel/getSymbolDetails.ts
@@ -8,6 +8,7 @@ import type { McpToolDef, McpContext } from "@internal/types";
 import type { LSPClient } from "@internal/lsp-client";
 import { pathToFileURL } from "url";
 import { join } from "path";
+import { uriToPath } from "../../utils/uriHelpers.ts";
 import { readFile } from "fs/promises";
 import { existsSync } from "fs";
 import { withLSPOperation, resolveLineParameter } from "@internal/lsp-client";
@@ -235,7 +236,7 @@ async function getSymbolDetailsImpl(
           const uri = "targetUri" in def ? def.targetUri : def.uri;
           const range = "targetRange" in def ? def.targetRange : def.range;
 
-          const defPath = uri.replace("file://", "");
+          const defPath = uriToPath(uri);
           const defRelativePath = defPath.replace(rootPath + "/", "");
 
           result.definition = {
@@ -280,7 +281,7 @@ async function getSymbolDetailsImpl(
         const refsToShow = referencesResult.slice(0, 20);
 
         for (const ref of refsToShow) {
-          const refPath = ref.uri.replace("file://", "");
+          const refPath = uriToPath(ref.uri);
           const refRelativePath = refPath.replace(rootPath + "/", "");
 
           const refEntry: any = {

--- a/src/tools/highlevel/symbolResolverTools.ts
+++ b/src/tools/highlevel/symbolResolverTools.ts
@@ -6,6 +6,7 @@ import type { McpToolDef } from "@internal/types";
 import { z } from "zod";
 import { resolve } from "path";
 import { readFile } from "fs/promises";
+import { uriToPath } from "../../utils/uriHelpers.ts";
 import {
   getAvailableExternalSymbols,
   parseImports,
@@ -101,7 +102,7 @@ async function handleResolveSymbol(args: any) {
       symbol: {
         name: resolution.symbol.name,
         kind: getSymbolKindName(resolution.symbol.kind),
-        location: resolution.symbol.location.uri.replace("file://", ""),
+        location: uriToPath(resolution.symbol.location.uri),
         detail: resolution.symbol.detail,
       },
     },

--- a/src/tools/lsp/references.ts
+++ b/src/tools/lsp/references.ts
@@ -7,6 +7,7 @@ import path from "path";
 import type { ErrorContext } from "@internal/lsp-client";
 import { formatError, validateLineAndSymbol } from "@internal/lsp-client";
 import { pathToFileURL } from "url";
+import { uriToPath } from "../../utils/uriHelpers.ts";
 
 // Helper functions
 function readFileWithMetadata(root: string, filePath: string) {
@@ -115,7 +116,7 @@ async function findReferencesWithLSP(
     const references: Reference[] = [];
 
     for (const location of locations) {
-      const refPath = location.uri?.replace("file://", "") || "";
+      const refPath = location.uri ? uriToPath(location.uri) : "";
       let refContent: string;
       try {
         refContent = readFileSync(refPath, "utf-8");

--- a/src/tools/lsp/rename.ts
+++ b/src/tools/lsp/rename.ts
@@ -2,6 +2,7 @@ import type { LSPClient } from "@internal/lsp-client";
 import { z } from "zod";
 import { err, ok, type Result } from "neverthrow";
 import { applyTextEdits } from "../../utils/applyTextEdits.ts";
+import { uriToPath } from "../../utils/uriHelpers.ts";
 // Helper functions
 function parseLineNumber(content: string, line: number | string): number {
   if (typeof line === "number") {
@@ -262,7 +263,7 @@ async function applyWorkspaceEdit(
   if (workspaceEdit.changes) {
     for (const [uri, _edits] of Object.entries(workspaceEdit.changes)) {
       if (!uri) continue;
-      const filePath = uri.replace("file://", "");
+      const filePath = uriToPath(uri);
       const content = readFileSync(filePath, "utf-8");
       allFileContents.set(filePath, content.split("\n"));
     }
@@ -271,7 +272,7 @@ async function applyWorkspaceEdit(
   if (workspaceEdit.documentChanges) {
     for (const change of workspaceEdit.documentChanges) {
       if ("textDocument" in change && change.textDocument?.uri) {
-        const filePath = change.textDocument.uri.replace("file://", "");
+        const filePath = uriToPath(change.textDocument.uri);
         if (!allFileContents.has(filePath)) {
           const content = readFileSync(filePath, "utf-8");
           allFileContents.set(filePath, content.split("\n"));
@@ -284,7 +285,7 @@ async function applyWorkspaceEdit(
   if (workspaceEdit.changes) {
     for (const [uri, edits] of Object.entries(workspaceEdit.changes)) {
       if (!uri) continue;
-      const filePath = uri.replace("file://", "");
+      const filePath = uriToPath(uri);
       const lines = allFileContents.get(filePath);
       if (!lines) continue;
       const fileChanges = processTextEdits(filePath, lines, edits);
@@ -307,7 +308,7 @@ async function applyWorkspaceEdit(
         "edits" in change &&
         change.textDocument?.uri
       ) {
-        const filePath = change.textDocument.uri.replace("file://", "");
+        const filePath = uriToPath(change.textDocument.uri);
         const lines = allFileContents.get(filePath);
         if (!lines) continue;
         const fileChanges = processTextEdits(filePath, lines, change.edits);

--- a/src/utils/uriHelpers.test.ts
+++ b/src/utils/uriHelpers.test.ts
@@ -1,0 +1,97 @@
+import { describe, it, expect } from "vitest";
+import { uriToPath, pathToUri, normalizePath } from "./uriHelpers.ts";
+import { platform } from "os";
+
+describe("uriHelpers", () => {
+  describe("uriToPath", () => {
+    it("should convert file URI to path on Windows", () => {
+      if (platform() === "win32") {
+        expect(uriToPath("file:///C:/Users/test/file.ts")).toBe(
+          "C:\\Users\\test\\file.ts",
+        );
+        expect(uriToPath("file:///D:/Projects/app.js")).toBe(
+          "D:\\Projects\\app.js",
+        );
+      }
+    });
+
+    it("should convert file URI to path on Unix", () => {
+      if (platform() !== "win32") {
+        expect(uriToPath("file:///home/user/file.ts")).toBe(
+          "/home/user/file.ts",
+        );
+        expect(uriToPath("file:///usr/local/bin/app")).toBe(
+          "/usr/local/bin/app",
+        );
+      }
+    });
+
+    it("should handle spaces in paths", () => {
+      if (platform() === "win32") {
+        expect(uriToPath("file:///C:/Program%20Files/test.ts")).toBe(
+          "C:\\Program Files\\test.ts",
+        );
+      } else {
+        expect(uriToPath("file:///home/user%20name/file.ts")).toBe(
+          "/home/user name/file.ts",
+        );
+      }
+    });
+
+    it("should throw error for invalid URIs", () => {
+      expect(() => uriToPath("http://example.com")).toThrow("Invalid file URI");
+      expect(() => uriToPath("/path/to/file")).toThrow("Invalid file URI");
+    });
+  });
+
+  describe("pathToUri", () => {
+    it("should convert Windows path to file URI", () => {
+      if (platform() === "win32") {
+        const uri = pathToUri("C:\\Users\\test\\file.ts");
+        expect(uri).toMatch(/^file:\/\/\/[A-Z]:\/Users\/test\/file\.ts$/);
+      }
+    });
+
+    it("should convert Unix path to file URI", () => {
+      if (platform() !== "win32") {
+        expect(pathToUri("/home/user/file.ts")).toBe(
+          "file:///home/user/file.ts",
+        );
+      }
+    });
+
+    it("should handle spaces in paths", () => {
+      if (platform() === "win32") {
+        const uri = pathToUri("C:\\Program Files\\test.ts");
+        expect(uri).toMatch(/^file:\/\/\/[A-Z]:\/Program%20Files\/test\.ts$/);
+      } else {
+        expect(pathToUri("/home/user name/file.ts")).toBe(
+          "file:///home/user%20name/file.ts",
+        );
+      }
+    });
+  });
+
+  describe("normalizePath", () => {
+    it("should normalize Windows paths", () => {
+      if (platform() === "win32") {
+        expect(normalizePath("C:\\Users\\test\\file.ts")).toBe(
+          "C:/Users/test/file.ts",
+        );
+        expect(normalizePath("c:\\Users\\test\\file.ts")).toBe(
+          "C:/Users/test/file.ts",
+        );
+      }
+    });
+
+    it("should normalize Unix paths", () => {
+      expect(normalizePath("/home/user/file.ts")).toBe("/home/user/file.ts");
+    });
+
+    it("should handle mixed separators", () => {
+      expect(normalizePath("C:\\Users/test\\sub/file.ts")).toBe(
+        "C:/Users/test/sub/file.ts",
+      );
+    });
+  });
+});

--- a/src/utils/uriHelpers.ts
+++ b/src/utils/uriHelpers.ts
@@ -1,0 +1,56 @@
+import { fileURLToPath, pathToFileURL } from "url";
+import { isAbsolute, resolve } from "path";
+
+/**
+ * Convert a file URI to a filesystem path
+ * Handles Windows paths correctly (file:///C:/path)
+ */
+export function uriToPath(uri: string): string {
+  if (!uri.startsWith("file://")) {
+    throw new Error(`Invalid file URI: ${uri}`);
+  }
+
+  try {
+    return fileURLToPath(uri);
+  } catch (error) {
+    // Fallback for malformed URIs
+    // Remove file:// prefix and handle Windows drive letters
+    let path = uri.replace(/^file:\/\/\/?/, "");
+
+    // On Windows, ensure drive letter is formatted correctly
+    if (process.platform === "win32") {
+      // Convert /C:/path to C:/path
+      path = path.replace(/^\/([A-Za-z]):/, "$1:");
+    }
+
+    return path;
+  }
+}
+
+/**
+ * Convert a filesystem path to a file URI
+ * Handles Windows paths correctly (C:\path -> file:///C:/path)
+ */
+export function pathToUri(filePath: string): string {
+  // Ensure absolute path
+  const absolutePath = isAbsolute(filePath) ? filePath : resolve(filePath);
+
+  // pathToFileURL handles Windows paths correctly
+  return pathToFileURL(absolutePath).toString();
+}
+
+/**
+ * Normalize a path for consistent comparison
+ * Handles Windows backslashes and case-insensitive filesystems
+ */
+export function normalizePath(filePath: string): string {
+  // Replace backslashes with forward slashes for consistency
+  let normalized = filePath.replace(/\\/g, "/");
+
+  // On Windows, normalize drive letter to uppercase
+  if (process.platform === "win32") {
+    normalized = normalized.replace(/^[a-z]:/, (match) => match.toUpperCase());
+  }
+
+  return normalized;
+}

--- a/tests/indexer/integration.test.ts
+++ b/tests/indexer/integration.test.ts
@@ -6,6 +6,7 @@ import { describe, it, expect, beforeEach, vi } from "vitest";
 import { SymbolIndex, MemoryCache } from "@internal/code-indexer";
 import { createLSPSymbolProvider, type LSPClient } from "@internal/lsp-client";
 import { SymbolKind } from "vscode-languageserver-types";
+import { fileURLToPath } from "url";
 
 describe("Indexer Integration", () => {
   let symbolIndex: SymbolIndex;
@@ -52,7 +53,7 @@ describe("Indexer Integration", () => {
     const symbolProvider = createLSPSymbolProvider(
       mockLSPClient,
       async (uri: string) => {
-        const path = uri.replace("file://", "");
+        const path = fileURLToPath(uri);
         return await mockFileSystem.readFile(path);
       },
     );

--- a/tests/integration/windows-paths.test.ts
+++ b/tests/integration/windows-paths.test.ts
@@ -1,0 +1,86 @@
+import { describe, it, expect, beforeAll, afterAll } from "vitest";
+import { fileURLToPath, pathToFileURL } from "url";
+import { resolve, join } from "path";
+import { existsSync, mkdirSync, writeFileSync, rmSync } from "fs";
+import { platform } from "os";
+import { uriToPath, pathToUri } from "../../src/utils/uriHelpers.ts";
+
+describe("Windows Path Integration", () => {
+  const isWindows = platform() === "win32";
+  const testDir = resolve("test-windows-paths");
+  const testFile = join(testDir, "test file with spaces.ts");
+
+  beforeAll(() => {
+    // Create test directory and file
+    if (!existsSync(testDir)) {
+      mkdirSync(testDir, { recursive: true });
+    }
+    writeFileSync(testFile, 'export const test = "hello world";');
+  });
+
+  afterAll(() => {
+    // Clean up
+    if (existsSync(testDir)) {
+      rmSync(testDir, { recursive: true, force: true });
+    }
+  });
+
+  it("should handle round-trip conversion of paths with spaces", () => {
+    const originalPath = testFile;
+    const uri = pathToUri(originalPath);
+    const convertedPath = uriToPath(uri);
+
+    // Normalize for comparison (resolve makes absolute paths)
+    expect(resolve(convertedPath)).toBe(resolve(originalPath));
+  });
+
+  it("should handle Windows drive letters correctly", () => {
+    if (isWindows) {
+      const testPaths = [
+        "C:\\Program Files\\test.ts",
+        "D:\\Projects\\my-app\\src\\index.ts",
+        "E:\\Users\\John Doe\\Documents\\file.js",
+      ];
+
+      for (const path of testPaths) {
+        const uri = pathToUri(path);
+        expect(uri).toMatch(/^file:\/\/\/[A-Z]:/);
+
+        // Convert back and check
+        const converted = uriToPath(uri);
+        expect(resolve(converted)).toBe(resolve(path));
+      }
+    }
+  });
+
+  it("should handle UNC paths on Windows", () => {
+    if (isWindows) {
+      // UNC paths are tricky, test the conversion logic
+      const uncPath = "\\\\server\\share\\file.ts";
+
+      // pathToFileURL should handle UNC paths
+      const uri = pathToFileURL(uncPath).toString();
+      expect(uri).toContain("file://");
+
+      // And convert back
+      const converted = fileURLToPath(uri);
+      expect(converted).toBe(uncPath);
+    }
+  });
+
+  it("should match Node.js built-in conversion", () => {
+    const testPaths = isWindows
+      ? ["C:\\test\\file.ts", "D:\\Program Files\\app.js"]
+      : ["/home/user/file.ts", "/usr/local/bin/app"];
+
+    for (const path of testPaths) {
+      const ourUri = pathToUri(path);
+      const nodeUri = pathToFileURL(path).toString();
+      expect(ourUri).toBe(nodeUri);
+
+      const ourPath = uriToPath(ourUri);
+      const nodePath = fileURLToPath(ourUri);
+      expect(ourPath).toBe(nodePath);
+    }
+  });
+});


### PR DESCRIPTION
## Summary
- Fixes Windows path handling issues in lsmcp by properly converting between file URIs and filesystem paths
- Replaces manual string manipulation with Node.js built-in `fileURLToPath` and `pathToFileURL` functions
- Adds comprehensive tests for Windows-specific scenarios

## Problem
The code was using `.replace("file://", "")` to convert URIs to paths, which doesn't work correctly on Windows where file URIs have three slashes (e.g., `file:///C:/path`) and need special handling for drive letters.

## Solution
- Created a centralized `uriHelpers` utility module with proper Windows path handling
- Updated 7 files to use the new utility functions instead of manual string manipulation
- Added tests covering Windows drive letters, spaces in paths, UNC paths, and round-trip conversions

## Test plan
- [x] Added unit tests for uriHelpers module
- [x] Added integration tests for Windows path scenarios
- [x] All tests pass on Windows
- [x] Build and type checking pass