### PR TITLE
fix: add Windows compatibility for language server spawning and path handling

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -154,6 +154,7 @@ tmp/
 bin/
 obj/
 tests/integration/tmp-*
+packages/lsp-client/tests/integration/tmp-*
 
 # Language-specific build artifacts in test fixtures
 tests/adapters/fixtures/rust/target/

--- a/packages/code-indexer/src/providers/externalLibraryProvider.test.ts
+++ b/packages/code-indexer/src/providers/externalLibraryProvider.test.ts
@@ -116,8 +116,9 @@ describe("ExternalLibraryProvider", () => {
       const files = await getNodeModulesDeclarations(tempDir);
 
       expect(files.length).toBeGreaterThan(0);
-      expect(files.some((f) => f.includes("@types/node"))).toBe(true);
-      expect(files.some((f) => f.includes("mock-lib"))).toBe(true);
+      // Normalize paths for cross-platform compatibility
+      expect(files.some((f) => f.replace(/\\/g, '/').includes("@types/node"))).toBe(true);
+      expect(files.some((f) => f.replace(/\\/g, '/').includes("mock-lib"))).toBe(true);
       expect(files.every((f) => f.endsWith(".d.ts"))).toBe(true);
     });
 
@@ -140,10 +141,13 @@ describe("ExternalLibraryProvider", () => {
       const libraries = await groupFilesByLibrary(files, tempDir);
 
       expect(libraries.size).toBeGreaterThan(0);
-      expect(libraries.has("@types/node")).toBe(true);
-      expect(libraries.has("mock-lib")).toBe(true);
+      // On Windows, the keys might use backslashes
+      const hasTypesNode = libraries.has("@types/node") || libraries.has("@types\\node");
+      const hasMockLib = libraries.has("mock-lib");
+      expect(hasTypesNode).toBe(true);
+      expect(hasMockLib).toBe(true);
 
-      const typesNode = libraries.get("@types/node");
+      const typesNode = libraries.get("@types/node") || libraries.get("@types\\node");
       expect(typesNode).toBeDefined();
       expect(typesNode?.name).toBe("@types/node");
       expect(typesNode?.version).toBe("20.0.0");

--- a/packages/code-indexer/src/providers/externalLibraryProvider.ts
+++ b/packages/code-indexer/src/providers/externalLibraryProvider.ts
@@ -330,9 +330,10 @@ export async function getAvailableTypescriptDependencies(
       const depPath = join(rootPath, "node_modules", dep);
       if (existsSync(depPath)) {
         // Check if it has TypeScript declarations
+        // Note: glob requires forward slashes even on Windows
         const patterns = [
-          join(depPath, "**/*.d.ts"),
-          join(rootPath, "node_modules", "@types", dep, "**/*.d.ts"),
+          join(depPath, "**/*.d.ts").replace(/\\/g, '/'),
+          join(rootPath, "node_modules", "@types", dep, "**/*.d.ts").replace(/\\/g, '/'),
         ];
 
         for (const pattern of patterns) {

--- a/packages/code-indexer/src/symbolIndex.test.ts
+++ b/packages/code-indexer/src/symbolIndex.test.ts
@@ -17,6 +17,8 @@ import {
 } from "./symbolIndex.ts";
 import { SymbolKind } from "vscode-languageserver-types";
 import { EventEmitter } from "events";
+import { resolve } from "path";
+import { pathToFileURL } from "url";
 
 // Mock LSP client
 const mockGetDocumentSymbols = vi.fn();
@@ -73,6 +75,9 @@ vi.mock("glob", () => ({
 
 describe("SymbolIndex", () => {
   let state: SymbolIndexState;
+  // Use platform-appropriate test path
+  const testRootPath = process.platform === 'win32' ? 'C:\\test\\project' : '/test/project';
+  const testFileUri = pathToFileURL(resolve(testRootPath, 'test.ts')).toString();
 
   beforeEach(() => {
     // Reset mock before each test
@@ -131,7 +136,7 @@ describe("SymbolIndex", () => {
     ]);
 
     state = {
-      rootPath: "/test/project",
+      rootPath: testRootPath,
       client: null,
       fileIndex: new Map(),
       symbolIndex: new Map(),
@@ -181,7 +186,7 @@ describe("SymbolIndex", () => {
       await indexFile(state, "test.ts");
 
       expect(fileIndexedHandler).toHaveBeenCalledWith({
-        uri: "file:///test/project/test.ts",
+        uri: testFileUri,
         symbolCount: 2, // Top-level symbols only (TestClass, testFunction)
         fromCache: false,
       });

--- a/packages/lsp-client/src/utils/typescript-helpers.ts
+++ b/packages/lsp-client/src/utils/typescript-helpers.ts
@@ -22,6 +22,7 @@ export async function createTypescriptLSPClient(
   const lspProcess = spawn("typescript-language-server", ["--stdio"], {
     cwd: root,
     stdio: ["pipe", "pipe", "pipe"],
+    shell: process.platform === 'win32', // Use shell on Windows
   });
 
   // Create LSP client

--- a/packages/lsp-client/tests/integration/lsp-definitions.test.ts
+++ b/packages/lsp-client/tests/integration/lsp-definitions.test.ts
@@ -51,6 +51,7 @@ describe("LSP get_definitions with include_body tests", () => {
     lspProcess = spawn(tsLspPath, ["--stdio"], {
       cwd: tmpDir,
       stdio: ["pipe", "pipe", "pipe"],
+      shell: process.platform === 'win32', // Use shell on Windows
     });
 
     // Initialize LSP client

--- a/packages/lsp-client/tests/integration/lsp-document-symbols.test.ts
+++ b/packages/lsp-client/tests/integration/lsp-document-symbols.test.ts
@@ -32,6 +32,7 @@ describe("lsp document symbols", { timeout: 30000 }, () => {
     lspProcess = spawn(tsLspPath, ["--stdio"], {
       cwd: __dirname,
       stdio: ["pipe", "pipe", "pipe"],
+      shell: process.platform === 'win32', // Use shell on Windows
     });
 
     // Initialize LSP client

--- a/packages/lsp-client/tests/integration/lsp-error-handling.test.ts
+++ b/packages/lsp-client/tests/integration/lsp-error-handling.test.ts
@@ -49,6 +49,7 @@ describe.skip("LSP error handling tests", { timeout: 30000 }, () => {
     lspProcess = spawn(tsLspPath, ["--stdio"], {
       cwd: __dirname,
       stdio: ["pipe", "pipe", "pipe"],
+      shell: process.platform === 'win32', // Use shell on Windows
     });
 
     // Initialize LSP client

--- a/packages/lsp-client/tests/integration/lsp-integration.test.ts
+++ b/packages/lsp-client/tests/integration/lsp-integration.test.ts
@@ -57,6 +57,7 @@ describe("LSP integration tests", () => {
     lspProcess = spawn(tsLspPath, ["--stdio"], {
       cwd: tmpDir, // Use tmpDir as working directory
       stdio: ["pipe", "pipe", "pipe"],
+      shell: process.platform === 'win32', // Use shell on Windows
     });
 
     // Initialize LSP client with tmpDir

--- a/packages/lsp-client/tests/integration/lsp-rename.test.ts
+++ b/packages/lsp-client/tests/integration/lsp-rename.test.ts
@@ -44,6 +44,7 @@ describe("lsp rename symbol", { timeout: 30000 }, () => {
     lspProcess = spawn(tsLspPath, ["--stdio"], {
       cwd: tmpDir,
       stdio: ["pipe", "pipe", "pipe"],
+      shell: process.platform === 'win32', // Use shell on Windows
     });
 
     // Initialize LSP client

--- a/src/lspServerRunner.ts
+++ b/src/lspServerRunner.ts
@@ -68,6 +68,7 @@ export async function runLanguageServerWithConfig(
         ...process.env,
         ...customEnv,
       },
+      shell: process.platform === "win32", // Use shell on Windows
     });
 
     // Create and initialize LSP client with the spawned process
@@ -255,6 +256,7 @@ export async function runLanguageServer(
         ...process.env,
         ...customEnv,
       },
+      shell: process.platform === "win32", // Use shell on Windows
     });
 
     // Initialize LSP client with the spawned process
@@ -391,6 +393,7 @@ export async function runCustomLspServer(
         ...process.env,
         ...customEnv,
       },
+      shell: process.platform === "win32", // Use shell on Windows
     });
 
     // Create and initialize LSP client

--- a/src/tools/highlevel/indexTools.test.ts
+++ b/src/tools/highlevel/indexTools.test.ts
@@ -1,4 +1,6 @@
 import { describe, it, expect, beforeEach, vi } from "vitest";
+import { pathToFileURL } from "url";
+import { resolve } from "path";
 import * as IndexerAdapter from "@internal/code-indexer";
 import { SymbolKind } from "vscode-languageserver-types";
 // Remove getLSPClient - no longer needed
@@ -93,6 +95,11 @@ vi.mock("gitaware-glob", () => ({
 }));
 
 describe("searchSymbolsTool", () => {
+  // Use platform-appropriate test paths
+  const testRoot = process.platform === "win32" ? "C:\\test" : "/test";
+  const makeTestUri = (filePath: string) =>
+    pathToFileURL(resolve(testRoot, filePath)).toString();
+
   beforeEach(() => {
     vi.clearAllMocks();
 
@@ -120,7 +127,7 @@ describe("searchSymbolsTool", () => {
           name: "TestClass",
           kind: SymbolKind.Class,
           location: {
-            uri: "file:///test/file.ts",
+            uri: makeTestUri("file.ts"),
             range: {
               start: { line: 0, character: 0 },
               end: { line: 10, character: 0 },
@@ -152,7 +159,7 @@ describe("searchSymbolsTool", () => {
           name: "TestClass",
           kind: SymbolKind.Class,
           location: {
-            uri: "file:///test/file.ts",
+            uri: makeTestUri("file.ts"),
             range: {
               start: { line: 0, character: 0 },
               end: { line: 10, character: 0 },
@@ -181,7 +188,7 @@ describe("searchSymbolsTool", () => {
           name: "TestClass",
           kind: SymbolKind.Class,
           location: {
-            uri: "file:///test/file.ts",
+            uri: makeTestUri("file.ts"),
             range: {
               start: { line: 0, character: 0 },
               end: { line: 10, character: 0 },
@@ -210,7 +217,7 @@ describe("searchSymbolsTool", () => {
           name: "TestInterface",
           kind: SymbolKind.Interface,
           location: {
-            uri: "file:///test/file.ts",
+            uri: makeTestUri("file.ts"),
             range: {
               start: { line: 0, character: 0 },
               end: { line: 5, character: 0 },
@@ -239,7 +246,7 @@ describe("searchSymbolsTool", () => {
           name: "Active",
           kind: SymbolKind.EnumMember,
           location: {
-            uri: "file:///test/file.ts",
+            uri: makeTestUri("file.ts"),
             range: {
               start: { line: 0, character: 0 },
               end: { line: 0, character: 10 },
@@ -264,7 +271,7 @@ describe("searchSymbolsTool", () => {
             name: "Active",
             kind: SymbolKind.EnumMember,
             location: {
-              uri: "file:///test/file.ts",
+              uri: makeTestUri("file.ts"),
               range: {
                 start: { line: 0, character: 0 },
                 end: { line: 0, character: 10 },
@@ -296,7 +303,7 @@ describe("searchSymbolsTool", () => {
           name: "TestClass",
           kind: SymbolKind.Class,
           location: {
-            uri: "file:///test/file.ts",
+            uri: makeTestUri("file.ts"),
             range: {
               start: { line: 0, character: 0 },
               end: { line: 10, character: 0 },
@@ -307,7 +314,7 @@ describe("searchSymbolsTool", () => {
           name: "TestInterface",
           kind: SymbolKind.Interface,
           location: {
-            uri: "file:///test/file.ts",
+            uri: makeTestUri("file.ts"),
             range: {
               start: { line: 12, character: 0 },
               end: { line: 15, character: 0 },
@@ -337,7 +344,7 @@ describe("searchSymbolsTool", () => {
           name: "TestClass",
           kind: SymbolKind.Class,
           location: {
-            uri: "file:///test/file.ts",
+            uri: makeTestUri("file.ts"),
             range: {
               start: { line: 0, character: 0 },
               end: { line: 10, character: 0 },
@@ -348,7 +355,7 @@ describe("searchSymbolsTool", () => {
           name: "TestInterface",
           kind: SymbolKind.Interface,
           location: {
-            uri: "file:///test/file.ts",
+            uri: makeTestUri("file.ts"),
             range: {
               start: { line: 12, character: 0 },
               end: { line: 15, character: 0 },
@@ -359,7 +366,7 @@ describe("searchSymbolsTool", () => {
           name: "testFunction",
           kind: SymbolKind.Function,
           location: {
-            uri: "file:///test/file.ts",
+            uri: makeTestUri("file.ts"),
             range: {
               start: { line: 17, character: 0 },
               end: { line: 20, character: 0 },
@@ -520,7 +527,7 @@ describe("searchSymbolsTool", () => {
           name: "TestClass",
           kind: SymbolKind.Class,
           location: {
-            uri: "file:///test/file1.ts",
+            uri: makeTestUri("file1.ts"),
             range: {
               start: { line: 0, character: 0 },
               end: { line: 10, character: 0 },
@@ -531,7 +538,7 @@ describe("searchSymbolsTool", () => {
           name: "testFunction",
           kind: SymbolKind.Function,
           location: {
-            uri: "file:///test/file1.ts",
+            uri: makeTestUri("file1.ts"),
             range: {
               start: { line: 12, character: 0 },
               end: { line: 15, character: 0 },
@@ -542,7 +549,7 @@ describe("searchSymbolsTool", () => {
           name: "TestInterface",
           kind: SymbolKind.Interface,
           location: {
-            uri: "file:///test/file2.ts",
+            uri: makeTestUri("file2.ts"),
             range: {
               start: { line: 0, character: 0 },
               end: { line: 5, character: 0 },
@@ -583,7 +590,7 @@ describe("searchSymbolsTool", () => {
           name: "ExampleSymbol",
           kind: SymbolKind.Class,
           location: {
-            uri: "file:///test/file.ts",
+            uri: makeTestUri("file.ts"),
             range: {
               start: { line: 0, character: 0 },
               end: { line: 1, character: 0 },
@@ -652,7 +659,7 @@ describe("searchSymbolsTool", () => {
           name: "TestClass",
           kind: SymbolKind.Class,
           location: {
-            uri: "file:///test/file1.ts",
+            uri: makeTestUri("file1.ts"),
             range: {
               start: { line: 0, character: 0 },
               end: { line: 10, character: 0 },
@@ -799,7 +806,7 @@ describe("searchSymbolsTool", () => {
           kind: SymbolKind.Method,
           containerName: "TestClass",
           location: {
-            uri: "file:///test/file.ts",
+            uri: makeTestUri("file.ts"),
             range: {
               start: { line: 5, character: 2 },
               end: { line: 7, character: 3 },
@@ -849,7 +856,7 @@ describe("searchSymbolsTool", () => {
           name: "TestClass",
           kind: SymbolKind.Class,
           location: {
-            uri: "file:///test/file.ts",
+            uri: makeTestUri("file.ts"),
             range: {
               start: { line: 0, character: 0 },
               end: { line: 10, character: 0 },
@@ -885,7 +892,7 @@ describe("searchSymbolsTool", () => {
           name: "TestClass",
           kind: SymbolKind.Class,
           location: {
-            uri: "file:///test/file.ts",
+            uri: makeTestUri("file.ts"),
             range: {
               start: { line: 0, character: 0 },
               end: { line: 10, character: 0 },
@@ -943,7 +950,7 @@ describe("searchSymbolsTool", () => {
           deprecated: true,
           detail: "() => void",
           location: {
-            uri: "file:///test/src/old.ts",
+            uri: makeTestUri("src/old.ts"),
             range: {
               start: { line: 10, character: 4 },
               end: { line: 12, character: 5 },
@@ -970,7 +977,7 @@ describe("searchSymbolsTool", () => {
         name: `Symbol${i}`,
         kind: SymbolKind.Class,
         location: {
-          uri: `file:///test/file${i}.ts`,
+          uri: makeTestUri(`file${i}.ts`),
           range: {
             start: { line: 0, character: 0 },
             end: { line: 10, character: 0 },

--- a/src/tools/highlevel/projectOverview.test.ts
+++ b/src/tools/highlevel/projectOverview.test.ts
@@ -3,6 +3,7 @@ import * as IndexerAdapter from "@internal/code-indexer";
 import * as fs from "fs/promises";
 import * as path from "path";
 import { SymbolKind } from "vscode-languageserver-types";
+import { pathToFileURL } from "url";
 
 // Mock the dependencies
 vi.mock("@internal/code-indexer", () => ({
@@ -39,6 +40,12 @@ import {
 import { getProjectOverviewTool } from "./projectOverview";
 
 describe("getProjectOverviewTool", () => {
+  // Use platform-appropriate test paths
+  const testRoot =
+    process.platform === "win32" ? "C:\\test\\project" : "/test/project";
+  const makeTestUri = (relativePath: string) =>
+    pathToFileURL(path.join(testRoot, relativePath)).toString();
+
   beforeEach(() => {
     vi.clearAllMocks();
 
@@ -60,7 +67,7 @@ describe("getProjectOverviewTool", () => {
   });
 
   it("should return project overview with basic structure", async () => {
-    const mockRoot = "/test/project";
+    const mockRoot = testRoot;
 
     // Mock package.json
     vi.mocked(fs.readFile).mockImplementation(async (filePath) => {
@@ -96,7 +103,7 @@ describe("getProjectOverviewTool", () => {
             name: "UserController",
             kind: SymbolKind.Class,
             location: {
-              uri: "file:///test/file.ts",
+              uri: makeTestUri("file.ts"),
               range: {
                 start: { line: 0, character: 0 },
                 end: { line: 0, character: 0 },
@@ -107,7 +114,7 @@ describe("getProjectOverviewTool", () => {
             name: "AuthService",
             kind: SymbolKind.Class,
             location: {
-              uri: "file:///test/file.ts",
+              uri: makeTestUri("file.ts"),
               range: {
                 start: { line: 0, character: 0 },
                 end: { line: 0, character: 0 },
@@ -118,7 +125,7 @@ describe("getProjectOverviewTool", () => {
             name: "DatabaseConnection",
             kind: SymbolKind.Class,
             location: {
-              uri: "file:///test/file.ts",
+              uri: makeTestUri("file.ts"),
               range: {
                 start: { line: 0, character: 0 },
                 end: { line: 0, character: 0 },
@@ -130,7 +137,7 @@ describe("getProjectOverviewTool", () => {
             name: "IUser",
             kind: SymbolKind.Interface,
             location: {
-              uri: "file:///test/file.ts",
+              uri: makeTestUri("file.ts"),
               range: {
                 start: { line: 0, character: 0 },
                 end: { line: 0, character: 0 },
@@ -141,7 +148,7 @@ describe("getProjectOverviewTool", () => {
             name: "IAuthToken",
             kind: SymbolKind.Interface,
             location: {
-              uri: "file:///test/file.ts",
+              uri: makeTestUri("file.ts"),
               range: {
                 start: { line: 0, character: 0 },
                 end: { line: 0, character: 0 },
@@ -153,7 +160,7 @@ describe("getProjectOverviewTool", () => {
             name: "main",
             kind: SymbolKind.Function,
             location: {
-              uri: "file:///test/file.ts",
+              uri: makeTestUri("file.ts"),
               range: {
                 start: { line: 0, character: 0 },
                 end: { line: 0, character: 0 },
@@ -164,7 +171,7 @@ describe("getProjectOverviewTool", () => {
             name: "initializeApp",
             kind: SymbolKind.Function,
             location: {
-              uri: "file:///test/file.ts",
+              uri: makeTestUri("file.ts"),
               range: {
                 start: { line: 0, character: 0 },
                 end: { line: 0, character: 0 },
@@ -175,7 +182,7 @@ describe("getProjectOverviewTool", () => {
             name: "connectDatabase",
             kind: SymbolKind.Function,
             location: {
-              uri: "file:///test/file.ts",
+              uri: makeTestUri("file.ts"),
               range: {
                 start: { line: 0, character: 0 },
                 end: { line: 0, character: 0 },
@@ -186,7 +193,7 @@ describe("getProjectOverviewTool", () => {
             name: "startServer",
             kind: SymbolKind.Function,
             location: {
-              uri: "file:///test/file.ts",
+              uri: makeTestUri("file.ts"),
               range: {
                 start: { line: 0, character: 0 },
                 end: { line: 0, character: 0 },
@@ -197,7 +204,7 @@ describe("getProjectOverviewTool", () => {
             name: "handleRequest",
             kind: SymbolKind.Function,
             location: {
-              uri: "file:///test/file.ts",
+              uri: makeTestUri("file.ts"),
               range: {
                 start: { line: 0, character: 0 },
                 end: { line: 0, character: 0 },
@@ -212,7 +219,7 @@ describe("getProjectOverviewTool", () => {
             name: "UserController",
             kind: SymbolKind.Class,
             location: {
-              uri: "file:///test/file.ts",
+              uri: makeTestUri("file.ts"),
               range: {
                 start: { line: 0, character: 0 },
                 end: { line: 0, character: 0 },
@@ -223,7 +230,7 @@ describe("getProjectOverviewTool", () => {
             name: "AuthService",
             kind: SymbolKind.Class,
             location: {
-              uri: "file:///test/file.ts",
+              uri: makeTestUri("file.ts"),
               range: {
                 start: { line: 0, character: 0 },
                 end: { line: 0, character: 0 },
@@ -234,7 +241,7 @@ describe("getProjectOverviewTool", () => {
             name: "DatabaseConnection",
             kind: SymbolKind.Class,
             location: {
-              uri: "file:///test/file.ts",
+              uri: makeTestUri("file.ts"),
               range: {
                 start: { line: 0, character: 0 },
                 end: { line: 0, character: 0 },
@@ -249,7 +256,7 @@ describe("getProjectOverviewTool", () => {
             name: "IUser",
             kind: SymbolKind.Interface,
             location: {
-              uri: "file:///test/file.ts",
+              uri: makeTestUri("file.ts"),
               range: {
                 start: { line: 0, character: 0 },
                 end: { line: 0, character: 0 },
@@ -260,7 +267,7 @@ describe("getProjectOverviewTool", () => {
             name: "IAuthToken",
             kind: SymbolKind.Interface,
             location: {
-              uri: "file:///test/file.ts",
+              uri: makeTestUri("file.ts"),
               range: {
                 start: { line: 0, character: 0 },
                 end: { line: 0, character: 0 },
@@ -275,7 +282,7 @@ describe("getProjectOverviewTool", () => {
             name: "main",
             kind: SymbolKind.Function,
             location: {
-              uri: "file:///test/file.ts",
+              uri: makeTestUri("file.ts"),
               range: {
                 start: { line: 0, character: 0 },
                 end: { line: 0, character: 0 },
@@ -286,7 +293,7 @@ describe("getProjectOverviewTool", () => {
             name: "initializeApp",
             kind: SymbolKind.Function,
             location: {
-              uri: "file:///test/file.ts",
+              uri: makeTestUri("file.ts"),
               range: {
                 start: { line: 0, character: 0 },
                 end: { line: 0, character: 0 },
@@ -297,7 +304,7 @@ describe("getProjectOverviewTool", () => {
             name: "connectDatabase",
             kind: SymbolKind.Function,
             location: {
-              uri: "file:///test/file.ts",
+              uri: makeTestUri("file.ts"),
               range: {
                 start: { line: 0, character: 0 },
                 end: { line: 0, character: 0 },
@@ -308,7 +315,7 @@ describe("getProjectOverviewTool", () => {
             name: "startServer",
             kind: SymbolKind.Function,
             location: {
-              uri: "file:///test/file.ts",
+              uri: makeTestUri("file.ts"),
               range: {
                 start: { line: 0, character: 0 },
                 end: { line: 0, character: 0 },
@@ -319,7 +326,7 @@ describe("getProjectOverviewTool", () => {
             name: "handleRequest",
             kind: SymbolKind.Function,
             location: {
-              uri: "file:///test/file.ts",
+              uri: makeTestUri("file.ts"),
               range: {
                 start: { line: 0, character: 0 },
                 end: { line: 0, character: 0 },
@@ -453,7 +460,7 @@ describe("getProjectOverviewTool", () => {
       name: `Class${i}`,
       kind: SymbolKind.Class,
       location: {
-        uri: "file:///test/file.ts",
+        uri: makeTestUri("file.ts"),
         range: {
           start: { line: 0, character: 0 },
           end: { line: 0, character: 0 },
@@ -465,7 +472,7 @@ describe("getProjectOverviewTool", () => {
       name: `function${i}`,
       kind: SymbolKind.Function,
       location: {
-        uri: "file:///test/file.ts",
+        uri: makeTestUri("file.ts"),
         range: {
           start: { line: 0, character: 0 },
           end: { line: 0, character: 0 },
@@ -477,7 +484,7 @@ describe("getProjectOverviewTool", () => {
       name: `Interface${i}`,
       kind: SymbolKind.Interface,
       location: {
-        uri: "file:///test/file.ts",
+        uri: makeTestUri("file.ts"),
         range: {
           start: { line: 0, character: 0 },
           end: { line: 0, character: 0 },
@@ -494,7 +501,7 @@ describe("getProjectOverviewTool", () => {
         return manyClasses.map((c) => ({
           ...c,
           location: {
-            uri: "file:///test/file.ts",
+            uri: makeTestUri("file.ts"),
             range: {
               start: { line: 0, character: 0 },
               end: { line: 0, character: 0 },
@@ -568,7 +575,7 @@ describe("getProjectOverviewTool", () => {
             name: "func1",
             kind: SymbolKind.Function,
             location: {
-              uri: "file:///test/project/src/index.ts",
+              uri: makeTestUri("src/index.ts"),
               range: {
                 start: { line: 0, character: 0 },
                 end: { line: 0, character: 0 },
@@ -579,7 +586,7 @@ describe("getProjectOverviewTool", () => {
             name: "func2",
             kind: SymbolKind.Function,
             location: {
-              uri: "file:///test/project/src/utils/helper.ts",
+              uri: makeTestUri("src/utils/helper.ts"),
               range: {
                 start: { line: 0, character: 0 },
                 end: { line: 0, character: 0 },
@@ -590,7 +597,7 @@ describe("getProjectOverviewTool", () => {
             name: "func3",
             kind: SymbolKind.Function,
             location: {
-              uri: "file:///test/project/tests/index.test.ts",
+              uri: makeTestUri("tests/index.test.ts"),
               range: {
                 start: { line: 0, character: 0 },
                 end: { line: 0, character: 0 },
@@ -601,7 +608,7 @@ describe("getProjectOverviewTool", () => {
             name: "func4",
             kind: SymbolKind.Function,
             location: {
-              uri: "file:///test/project/src/components/Button.tsx",
+              uri: makeTestUri("src/components/Button.tsx"),
               range: {
                 start: { line: 0, character: 0 },
                 end: { line: 0, character: 0 },
@@ -654,7 +661,7 @@ describe("getProjectOverviewTool", () => {
             name: "TestClass",
             kind: SymbolKind.Class,
             location: {
-              uri: "file:///test/file.ts",
+              uri: makeTestUri("file.ts"),
               range: {
                 start: { line: 0, character: 0 },
                 end: { line: 0, character: 0 },

--- a/tests/helpers/lsp-test-helpers.ts
+++ b/tests/helpers/lsp-test-helpers.ts
@@ -42,6 +42,7 @@ export async function setupLSPForTesting(
   const lspProcess = spawn(tsLspPath, ["--stdio"], {
     cwd: workingDir,
     stdio: ["pipe", "pipe", "pipe"],
+    shell: process.platform === "win32", // Use shell on Windows
   });
 
   // Monitor process startup for debugging

--- a/tests/integration/binFindStrategy.test.ts
+++ b/tests/integration/binFindStrategy.test.ts
@@ -122,6 +122,7 @@ export { add };
       const lspProcess = spawn(command, args, {
         cwd: tmpDir,
         stdio: ["pipe", "pipe", "pipe"],
+        shell: process.platform === "win32", // Use shell on Windows
       });
 
       // Handle spawn errors

--- a/tests/integration/completion.test.ts
+++ b/tests/integration/completion.test.ts
@@ -228,6 +228,7 @@ describe("Completion Integration Tests", () => {
         // Spawn tsgo process
         const lspProcess = spawn("npx", ["tsgo", "--lsp", "--stdio"], {
           cwd: process.cwd(),
+          shell: process.platform === "win32", // Use shell on Windows
         });
 
         // Create and initialize LSP client

--- a/tests/languages/testHelpers.ts
+++ b/tests/languages/testHelpers.ts
@@ -31,6 +31,7 @@ export async function testLspConnection(
     const lspProcess = spawn(command, args, {
       cwd: projectPath,
       stdio: ["pipe", "pipe", "pipe"],
+      shell: process.platform === "win32", // Use shell on Windows
     });
 
     // Create LSP client
@@ -133,6 +134,7 @@ export async function setupLSPForTest(root: string): Promise<any> {
   const lspProcess = spawn(command, args, {
     cwd: root,
     stdio: ["pipe", "pipe", "pipe"],
+    shell: process.platform === "win32", // Use shell on Windows
   });
 
   testClient = createLSPClient({


### PR DESCRIPTION
## Summary
This PR fixes Windows compatibility issues preventing language servers from starting and tests from passing on Windows systems.

## Changes
- Add `shell: true` option for spawn calls on Windows platform to fix language server startup issues
- Fix file URI generation to handle Windows drive letters correctly
- Normalize glob patterns to use forward slashes on Windows (required by glob library)
- Update test assertions to be platform-agnostic for path separators
- Add test temp directories to .gitignore

## Test Results
After these changes:
- **38 out of 51 test files passing** (75% pass rate)
- **381 out of 453 tests passing** (84% pass rate)
- TypeScript LSP tests now run successfully on Windows

## Remaining Issues (not addressed in this PR)
- Windows file locking issues during temp directory cleanup (EBUSY errors)
- Some LSP operations like rename not fully working on Windows
- Deno LSP connection issues

## Fixes
Fixes #32

## Testing
Tested on Windows 10 with Node.js 24.6.0 and pnpm 9.15.0
```bash
pnpm install
pnpm build  
pnpm test
```